### PR TITLE
chore: standardize .github — dependabot, CODEOWNERS, PR template (INFRA-6819)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @worldcoin/infrastructure

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+Requestor/Issue: 
+Tested (yes/no): 
+Description/Why: 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[github-actions]"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[npm]"
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[docker]"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds standard `.github/` files (.github/dependabot.yml, CODEOWNERS, PR-template).

Part of INFRA-6819. Dependabot grouped per ecosystem; registry-free (public deps only).

🤖 Generated with Claude Code